### PR TITLE
Support PHP 8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,5 +176,5 @@ workflows:
       - matrix-conditions:
           matrix:
             parameters:
-              version: ["8.1", "8.0", "7.4"]
+              version: ["8.2", "8.1", "8.0", "7.4"]
               install-flags: ["", "--prefer-lowest"]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Exclude build/test files from archive
+/.circleci        export-ignore
+/tests            export-ignore
+/.editorconfig    export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/phpcs.xml        export-ignore
+/phpunit.xml      export-ignore
+/rector.php       export-ignore
+
+# Configure diff output for .php and .phar files.
+*.php diff=php

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Exclude build/test files from archive
 /.circleci        export-ignore
-/tests            export-ignore
+/test             export-ignore
 /.editorconfig    export-ignore
 /.gitattributes   export-ignore
 /.gitignore       export-ignore

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,13 @@
         "php": ">=7.4",
         "ext-json": "*",
         "fmizzell/maquina": "^1.1.1",
-        "getdkan/contracts": "dev-php-82"
+        "getdkan/contracts": "^1.1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "rector/rector": "^0.15.17",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.7",
+        "symfony/phpunit-bridge": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "fmizzell/maquina": "^1.1.1",
-        "getdkan/contracts": "^1.1.1"
+        "getdkan/contracts": "dev-php-82"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" verbose="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         verbose="false">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">src</directory>
+      <directory>src</directory>
     </include>
   </coverage>
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
+  <php>
+    <!-- Don't fail for external dependencies. -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
+  </php>
   <testsuites>
     <testsuite name="all">
-      <directory suffix="Test.php" phpVersion="7.2" phpVersionOperator="&gt;=">test</directory>
+      <directory>test</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -3,20 +3,40 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+
     $rectorConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/test',
     ]);
 
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_74,
+    // Try to figure out type hints.
+    SetList::TYPE_DECLARATION,
+    // Bring us up to PHP 7.4.
+    LevelSetList::UP_TO_PHP_74,
     ]);
 
     $rectorConfig->skip([
-        JsonThrowOnErrorRector::class,
+    // Don't throw errors on JSON parse problems. Yet.
+    // @todo Throw errors and deal with them appropriately.
+    JsonThrowOnErrorRector::class,
+    // We like our tags.
+    RemoveUselessParamTagRector::class,
+    RemoveUselessReturnTagRector::class,
+    RemoveUselessVarTagRector::class,
     ]);
+
+    $rectorConfig->importNames();
+    $rectorConfig->importShortClasses(false);
 };

--- a/rector.php
+++ b/rector.php
@@ -8,33 +8,37 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
-use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {
-
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
-
     $rectorConfig->paths([
-        __DIR__ . '/src',
-        __DIR__ . '/test',
+    __DIR__ . '/src',
+    __DIR__ . '/test',
     ]);
 
+  // Our base version of PHP.
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+
     $rectorConfig->sets([
-    // Try to figure out type hints.
-    SetList::TYPE_DECLARATION,
-    // Bring us up to PHP 7.4.
-    LevelSetList::UP_TO_PHP_74,
+        SetList::PHP_82,
+        // Please no dead code or unneeded variables.
+        SetList::DEAD_CODE,
+        // Try to figure out type hints.
+        SetList::TYPE_DECLARATION,
     ]);
 
     $rectorConfig->skip([
-    // Don't throw errors on JSON parse problems. Yet.
-    // @todo Throw errors and deal with them appropriately.
-    JsonThrowOnErrorRector::class,
-    // We like our tags.
-    RemoveUselessParamTagRector::class,
-    RemoveUselessReturnTagRector::class,
-    RemoveUselessVarTagRector::class,
+        // Don't throw errors on JSON parse problems. Yet.
+        // @todo Throw errors and deal with them appropriately.
+        JsonThrowOnErrorRector::class,
+        // We like our tags. Please don't remove them.
+        RemoveUselessParamTagRector::class,
+        RemoveUselessReturnTagRector::class,
+        RemoveUselessVarTagRector::class,
+        ArrayShapeFromConstantArrayReturnRector::class,
+        AddMethodCallBasedStrictParamTypeRector::class,
     ]);
 
     $rectorConfig->importNames();

--- a/src/Parser/Csv.php
+++ b/src/Parser/Csv.php
@@ -54,7 +54,6 @@ class Csv implements ParserInterface, \JsonSerializable
         if (strlen($chunk) > 0) {
             $chars = str_split($chunk);
             foreach ($chars as $char) {
-                $this->machine->getCurrentStates();
                 $char_type = $this->getCharType($char);
 
                 $this->machine->processInput($char_type);

--- a/src/Parser/Csv.php
+++ b/src/Parser/Csv.php
@@ -54,7 +54,7 @@ class Csv implements ParserInterface, \JsonSerializable
         if (strlen($chunk) > 0) {
             $chars = str_split($chunk);
             foreach ($chars as $char) {
-                $initial_states = $this->machine->getCurrentStates();
+                $this->machine->getCurrentStates();
                 $char_type = $this->getCharType($char);
 
                 $this->machine->processInput($char_type);
@@ -62,7 +62,7 @@ class Csv implements ParserInterface, \JsonSerializable
                 $this->lastCharType = $char_type;
                 $end_states = $this->machine->getCurrentStates();
 
-                $this->processTransition($initial_states, $end_states, $char);
+                $this->processTransition($end_states, $char);
             }
         } else {
             throw new \Exception("The CSV parser can not parse empty chunks.");
@@ -162,7 +162,7 @@ class Csv implements ParserInterface, \JsonSerializable
         $this->field = "";
     }
 
-    private function processTransition($initialStates, $endStates, string $input): void
+    private function processTransition($endStates, string $input): void
     {
         foreach ($endStates as $endState) {
             $this->processTransitionHelper($endState, $input);

--- a/src/Parser/Csv.php
+++ b/src/Parser/Csv.php
@@ -18,6 +18,9 @@ class Csv implements ParserInterface, \JsonSerializable
     private $fields;
     private string $field;
 
+    /**
+     * @var sm
+     */
     public $machine;
 
     private $lastCharType;
@@ -25,12 +28,12 @@ class Csv implements ParserInterface, \JsonSerializable
 
     private bool $trailingDelimiter = false;
 
-    public function activateTrailingDelimiter()
+    public function activateTrailingDelimiter(): void
     {
         $this->trailingDelimiter = true;
     }
 
-    public static function getParser($delimiter = ",", $quote = '"', $escape = "\\", $record_end = ["\n", "\r"])
+    public static function getParser($delimiter = ",", $quote = '"', $escape = "\\", $record_end = ["\n", "\r"]): self
     {
         return new self($delimiter, $quote, $escape, $record_end);
     }
@@ -91,7 +94,7 @@ class Csv implements ParserInterface, \JsonSerializable
         return $records;
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->field = "";
         $this->fields = [];
@@ -116,7 +119,7 @@ class Csv implements ParserInterface, \JsonSerializable
         }
     }
 
-    private function getCharType($char)
+    private function getCharType(string $char)
     {
         $type = sm::CHAR_TYPE_OTHER;
         if (in_array($char, $this->recordEnd)) {
@@ -133,12 +136,12 @@ class Csv implements ParserInterface, \JsonSerializable
         return $type;
     }
 
-    private function addCharToField($char)
+    private function addCharToField(string $char): void
     {
         $this->field .= $char;
     }
 
-    private function createNewRecord()
+    private function createNewRecord(): void
     {
         $this->createNewField();
         if (!empty($this->fields)) {
@@ -147,7 +150,7 @@ class Csv implements ParserInterface, \JsonSerializable
         }
     }
 
-    private function createNewField()
+    private function createNewField(): void
     {
         if ($this->quoted) {
             $this->fields[] = $this->field;
@@ -159,14 +162,14 @@ class Csv implements ParserInterface, \JsonSerializable
         $this->field = "";
     }
 
-    private function processTransition($initialStates, $endStates, $input)
+    private function processTransition($initialStates, $endStates, string $input): void
     {
         foreach ($endStates as $endState) {
             $this->processTransitionHelper($endState, $input);
         }
     }
 
-    private function processTransitionHelper($endState, $input)
+    private function processTransitionHelper($endState, string $input): void
     {
         if ($endState == sm::STATE_RECORD_END) {
             $this->createNewRecord();

--- a/src/Parser/StateMachine.php
+++ b/src/Parser/StateMachine.php
@@ -46,7 +46,7 @@ class StateMachine extends MachineOfMachines
         $this->addQuoteFinalTransitions();
     }
 
-    private function addNewFieldTransitions()
+    private function addNewFieldTransitions(): void
     {
         $this->recordEndAndNewFieldCommons(self::STATE_NEW_FIELD);
 
@@ -57,7 +57,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function noCaptureAndRedundantRecordEndCommon($state)
+    private function noCaptureAndRedundantRecordEndCommon(string $state): void
     {
         $this->addTransition(
             $state,
@@ -90,7 +90,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function addNoCaptureTransitions()
+    private function addNoCaptureTransitions(): void
     {
         $this->noCaptureAndRedundantRecordEndCommon(self::STATE_NO_CAPTURE);
 
@@ -101,7 +101,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function recordEndAndNewFieldCommons($state)
+    private function recordEndAndNewFieldCommons(string $state): void
     {
         $this->addTransition(
             $state,
@@ -128,7 +128,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function addRecordEndTransitions()
+    private function addRecordEndTransitions(): void
     {
         $this->recordEndAndNewFieldCommons(self::STATE_RECORD_END);
 
@@ -139,7 +139,7 @@ class StateMachine extends MachineOfMachines
          );
     }
 
-    private function addRedundantRecordEndTranstions()
+    private function addRedundantRecordEndTranstions(): void
     {
         $this->noCaptureAndRedundantRecordEndCommon(self::STATE_REDUNDANT_RECORD_END);
 
@@ -150,7 +150,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function addCaptureTransitions()
+    private function addCaptureTransitions(): void
     {
         $this->addTransition(
             self::STATE_CAPTURE,
@@ -180,7 +180,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function addEscapeTransitions()
+    private function addEscapeTransitions(): void
     {
         $this->addTransition(
             self::STATE_ESCAPE,
@@ -196,7 +196,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function addQuoteInitialTransitions()
+    private function addQuoteInitialTransitions(): void
     {
         $this->addTransition(
             self::STATE_QUOTE_INITIAL,
@@ -223,7 +223,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function addQuoteCaptureTransitions()
+    private function addQuoteCaptureTransitions(): void
     {
         $this->addTransition(
             self::STATE_QUOTE_CAPTURE,
@@ -255,7 +255,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function addQuoteEscapeQuoteTransitions()
+    private function addQuoteEscapeQuoteTransitions(): void
     {
         $this->addTransition(
             self::STATE_QUOTE_ESCAPE_QUOTE,
@@ -264,7 +264,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function addQuoteEscapeTransitions()
+    private function addQuoteEscapeTransitions(): void
     {
         $this->addTransition(
             self::STATE_QUOTE_ESCAPE,
@@ -280,7 +280,7 @@ class StateMachine extends MachineOfMachines
         );
     }
 
-    private function addQuoteFinalTransitions()
+    private function addQuoteFinalTransitions(): void
     {
         $this->addTransition(
             self::STATE_QUOTE_FINAL,

--- a/test/CsvParserTest.php
+++ b/test/CsvParserTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 class CsvParserTest extends TestCase
 {
 
-    private function parse($string)
+    private function parse(string $string)
     {
         $parser = Csv::getParser(',', '"', "\\", ["\r", "\n"]);
         $parser->feed($string);
@@ -21,13 +21,13 @@ class CsvParserTest extends TestCase
         return $parser;
     }
 
-    public function testEmptyString()
+    public function testEmptyString(): void
     {
         $this->expectExceptionMessage("The CSV parser can not parse empty chunks.");
         $this->parse('');
     }
 
-    public function testJustDelimiters()
+    public function testJustDelimiters(): void
     {
         $parser = $this->parse(',,');
         $record = $parser->getRecord();
@@ -36,7 +36,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testEmptyNewLineString()
+    public function testEmptyNewLineString(): void
     {
         $parser = $this->parse("\n");
         $record = $parser->getRecord();
@@ -45,7 +45,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testJustDelimitersNewLineString()
+    public function testJustDelimitersNewLineString(): void
     {
         $parser = $this->parse(",,\n,,");
         $record = $parser->getRecord();
@@ -57,7 +57,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testBlankString()
+    public function testBlankString(): void
     {
         $parser = $this->parse('   ');
         $record = $parser->getRecord();
@@ -66,7 +66,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testBlankJustDelimiters()
+    public function testBlankJustDelimiters(): void
     {
         $parser = $this->parse('  ,   ,    ');
         $record = $parser->getRecord();
@@ -75,7 +75,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testBlankNewLineString()
+    public function testBlankNewLineString(): void
     {
         $parser = $this->parse("  \n   ");
         $record = $parser->getRecord();
@@ -87,7 +87,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testBlankJustDelimitersNewLineString()
+    public function testBlankJustDelimitersNewLineString(): void
     {
         $parser = $this->parse("  ,   ,    \n  ,   ,    ");
         $record = $parser->getRecord();
@@ -99,7 +99,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOther()
+    public function testOther(): void
     {
         $parser = $this->parse('A');
         $record = $parser->getRecord();
@@ -108,7 +108,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherJustDelimiters()
+    public function testOtherJustDelimiters(): void
     {
         $parser = $this->parse('A,B,C');
         $record = $parser->getRecord();
@@ -117,7 +117,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherNewLineString()
+    public function testOtherNewLineString(): void
     {
         $parser = $this->parse("A\nB");
         $record = $parser->getRecord();
@@ -129,7 +129,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherJustDelimitersNewLineString()
+    public function testOtherJustDelimitersNewLineString(): void
     {
         $parser = $this->parse("A,B,C\nD,E,F");
         $record = $parser->getRecord();
@@ -141,7 +141,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherBlank()
+    public function testOtherBlank(): void
     {
         $parser = $this->parse('  A B  ');
         $record = $parser->getRecord();
@@ -150,7 +150,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherBlankJustDelimiters()
+    public function testOtherBlankJustDelimiters(): void
     {
         $parser = $this->parse(' A B ,B  C , CD');
         $record = $parser->getRecord();
@@ -159,7 +159,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherBlankNewLineString()
+    public function testOtherBlankNewLineString(): void
     {
         $parser = $this->parse("A B   \n   B  C");
         $record = $parser->getRecord();
@@ -171,7 +171,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherBlankJustDelimitersNewLineString()
+    public function testOtherBlankJustDelimitersNewLineString(): void
     {
         $parser = $this->parse(" AB,B C \n D  E,E   F ");
         $record = $parser->getRecord();
@@ -183,7 +183,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherBlankEscape()
+    public function testOtherBlankEscape(): void
     {
         $parser = $this->parse('  A \\' . "\n" . 'B\,  ');
         $record = $parser->getRecord();
@@ -192,7 +192,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherBlankEscapeJustDelimiters()
+    public function testOtherBlankEscapeJustDelimiters(): void
     {
         $parser = $this->parse(' A \\\B ,B \\' . "\n" . ' C , CD');
         $record = $parser->getRecord();
@@ -201,7 +201,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherBlankEscapeNewLineString()
+    public function testOtherBlankEscapeNewLineString(): void
     {
         $parser = $this->parse('A B \\' . "\n  \n" . ' \\,  B  C ');
         $record = $parser->getRecord();
@@ -213,7 +213,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testOtherBlankEscapeJustDelimitersNewLineString()
+    public function testOtherBlankEscapeJustDelimitersNewLineString(): void
     {
         $parser = $this->parse(' A \\' . "\n" . ' B,B C ' . "\n" . ' \\\D  E\,,E   F ');
         $record = $parser->getRecord();
@@ -225,7 +225,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testQuotes()
+    public function testQuotes(): void
     {
         $parser = $this->parse('""');
         $record = $parser->getRecord();
@@ -234,7 +234,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testQuoteDelimiters()
+    public function testQuoteDelimiters(): void
     {
         $parser = $this->parse('" A B " , " B ' . "\n" . ' C"');
         $record = $parser->getRecord();
@@ -243,7 +243,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testQuoteNewLineString()
+    public function testQuoteNewLineString(): void
     {
         $parser = $this->parse('  " A B ' . "\n" . '"  ' . "\n" . ' ", B \" C "');
         $record = $parser->getRecord();
@@ -255,7 +255,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testQuoteJustDelimitersNewLineString()
+    public function testQuoteJustDelimitersNewLineString(): void
     {
         $parser = $this->parse(' "A '. "\n" . ' B"  , "B C" ' . "\n" . ' "\\\D  E," , "E   F" ');
         $record = $parser->getRecord();
@@ -267,7 +267,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testDoubleQuoteEscaping()
+    public function testDoubleQuoteEscaping(): void
     {
         $parser = $this->parse('"S ""H"""');
         $record = $parser->getRecord();
@@ -291,7 +291,7 @@ class CsvParserTest extends TestCase
      * We went to make sure that when a string is cut in the middle of double
      * quote scaping, that the parser can still handle it without problems.
      */
-    public function testBrokenLookAhead()
+    public function testBrokenLookAhead(): void
     {
         $string1 = '"S "';
         $string2 = '"H"""';
@@ -305,7 +305,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testTrailingDelimiter()
+    public function testTrailingDelimiter(): void
     {
         $parser = $this->parse('H,F,' . "\n" . 'G,B,');
         $record = $parser->getRecord();
@@ -330,7 +330,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testMultiEnd()
+    public function testMultiEnd(): void
     {
         $parser = $this->parse('H,F' . "\n\r" . 'G,B');
         $record = $parser->getRecord();
@@ -357,7 +357,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
         $parser = Csv::getParser(',', '"', "\\", ["\r", "\n"]);
         $parser->feed("a,b,c,d\n");
@@ -377,7 +377,7 @@ class CsvParserTest extends TestCase
         $this->assertEquals($record2[0], 'e');
     }
 
-    public function testEndingWithNewLineString()
+    public function testEndingWithNewLineString(): void
     {
         $parser = $this->parse(",,\n,,\n");
         $record = $parser->getRecord();
@@ -389,7 +389,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testEndingWithWindowsNewLineString()
+    public function testEndingWithWindowsNewLineString(): void
     {
         $parser = $this->parse(",,\r\n,,\r\n");
         $record = $parser->getRecord();
@@ -401,7 +401,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testEndingWithMultipleNewLinesString()
+    public function testEndingWithMultipleNewLinesString(): void
     {
         $parser = $this->parse(",,\n,,\n\n\n");
         $record = $parser->getRecord();
@@ -413,7 +413,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testEndingWithMultipleWindowsNewLinesString()
+    public function testEndingWithMultipleWindowsNewLinesString(): void
     {
         $parser = $this->parse(",,\r\n,,\r\n\r\n\r\n");
         $record = $parser->getRecord();
@@ -425,7 +425,7 @@ class CsvParserTest extends TestCase
         $this->assertNull($parser->getRecord());
     }
 
-    public function testEmptyWindowsNewLineString()
+    public function testEmptyWindowsNewLineString(): void
     {
         $parser = $this->parse("\r\n");
         $record = $parser->getRecord();
@@ -437,7 +437,7 @@ class CsvParserTest extends TestCase
   /**
    * @covers ::finish
    */
-    public function testFinishException()
+    public function testFinishException(): void
     {
         $this->expectExceptionMessage('Machine did not halt');
 

--- a/test/FileTest.php
+++ b/test/FileTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class FileTest extends TestCase
 {
-    public function test()
+    public function test(): void
     {
         $parser = Csv::getParser();
         $parser->feed(file_get_contents(__DIR__ . "/data/countries.csv"));


### PR DESCRIPTION
- Adds PHP 8.2 to the testing matrix.
- Adds `.gitattributes` so packages exclude tests, etc.
- Rector adds some code quality.