### PR TITLE
Remove dependency on getdkan/contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "fmizzell/maquina": "^1.1.1",
-        "getdkan/contracts": "^1.1.2"
+        "fmizzell/maquina": "^1.1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": ">=7.4",
+        "ext-ctype": "*",
         "ext-json": "*",
         "fmizzell/maquina": "^1.1.1"
     },

--- a/rector.php
+++ b/rector.php
@@ -3,18 +3,13 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
-use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
-use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Set\ValueObject\SetList;
-use Rector\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
-    __DIR__ . '/src',
-    __DIR__ . '/test',
+        __DIR__ . '/src',
+        __DIR__ . '/test',
+        __DIR__ . '/rector.php',
     ]);
 
     $rectorConfig->sets([
@@ -25,6 +20,7 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::TYPE_DECLARATION,
     ]);
 
+    $rectorConfig->removeUnusedImports();
     $rectorConfig->importNames();
     $rectorConfig->importShortClasses(false);
 };

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\ValueObject\PhpVersion;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
@@ -18,27 +17,12 @@ return static function (RectorConfig $rectorConfig): void {
     __DIR__ . '/test',
     ]);
 
-  // Our base version of PHP.
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
-
     $rectorConfig->sets([
-        SetList::PHP_82,
+        SetList::PHP_74,
         // Please no dead code or unneeded variables.
         SetList::DEAD_CODE,
         // Try to figure out type hints.
         SetList::TYPE_DECLARATION,
-    ]);
-
-    $rectorConfig->skip([
-        // Don't throw errors on JSON parse problems. Yet.
-        // @todo Throw errors and deal with them appropriately.
-        JsonThrowOnErrorRector::class,
-        // We like our tags. Please don't remove them.
-        RemoveUselessParamTagRector::class,
-        RemoveUselessReturnTagRector::class,
-        RemoveUselessVarTagRector::class,
-        ArrayShapeFromConstantArrayReturnRector::class,
-        AddMethodCallBasedStrictParamTypeRector::class,
     ]);
 
     $rectorConfig->importNames();

--- a/src/Parser/Csv.php
+++ b/src/Parser/Csv.php
@@ -48,7 +48,7 @@ class Csv implements ParserInterface, \JsonSerializable
         $this->machine->stopRecording();
     }
 
-    public function feed(string $chunk): void
+    public function feed(string $chunk)
     {
         if (strlen($chunk) > 0) {
             $chars = str_split($chunk);
@@ -103,7 +103,7 @@ class Csv implements ParserInterface, \JsonSerializable
         $this->quoted = false;
     }
 
-    public function finish(): void
+    public function finish()
     {
         // There will be csv strings that do not end in a "end of record" char.
         // This will flush them.

--- a/src/Parser/Csv.php
+++ b/src/Parser/Csv.php
@@ -3,9 +3,8 @@
 
 namespace CsvParser\Parser;
 
-use Contracts\ParserInterface;
-use Maquina\StateMachine\MachineOfMachines;
 use CsvParser\Parser\StateMachine as sm;
+use Maquina\StateMachine\MachineOfMachines;
 
 class Csv implements ParserInterface, \JsonSerializable
 {

--- a/src/Parser/Csv.php
+++ b/src/Parser/Csv.php
@@ -48,7 +48,7 @@ class Csv implements ParserInterface, \JsonSerializable
         $this->machine->stopRecording();
     }
 
-    public function feed(string $chunk)
+    public function feed(string $chunk): void
     {
         if (strlen($chunk) > 0) {
             $chars = str_split($chunk);
@@ -103,7 +103,7 @@ class Csv implements ParserInterface, \JsonSerializable
         $this->quoted = false;
     }
 
-    public function finish()
+    public function finish(): void
     {
         // There will be csv strings that do not end in a "end of record" char.
         // This will flush them.

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -2,13 +2,39 @@
 
 namespace CsvParser\Parser;
 
+/**
+ * Interface for parsing CSV files.
+ */
 interface ParserInterface
 {
-    public function feed(string $chunk);
 
+    /**
+     * Feed a string into the parser.
+     *
+     * @param string $chunk
+     *   A chunk of the CSV being fed into the parser.
+     */
+    public function feed(string $chunk): void;
+
+    /**
+     * Get a record.
+     *
+     * @return array|null
+     *   The record as an array, or null.
+     */
     public function getRecord();
 
-    public function reset();
+    /**
+     * Reset the parser to an initialized state.
+     */
+    public function reset(): void;
 
-    public function finish();
+    /**
+     * At the end of a run of parsing, ensure there were no errors.
+     *
+     * @throws \Exception
+     *   Throws an exception if the state machine was out of sync with our
+     *   expectations.
+     */
+    public function finish(): void;
 }

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace CsvParser\Parser;
+
+interface ParserInterface
+{
+    public function feed(string $chunk);
+
+    public function getRecord();
+
+    public function reset();
+
+    public function finish();
+}


### PR DESCRIPTION
Release of this PR should coincide with the deprecations in https://github.com/GetDKAN/contracts/pull/16

- Moves `\Contracts\ParserInterface` into `\CsvParser\Parser\ParserInterface`.
- Improves interface docblocks.